### PR TITLE
Initialize Next.js chatbot skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# rob-and-hannah
-Life hack app
+# Rob and Hannah AI Assistant
+
+This project is an early prototype of a personal AI chatbot for Rob and Hannah. It uses Next.js 15 with the App Router, React 19, TypeScript and Tailwind CSS. Authentication is handled with Clerk and the chatbot communicates with OpenAI's API.
+
+## Development
+
+1. Install dependencies (requires Node.js 20+):
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file with your `OPENAI_API_KEY` and Clerk keys.
+3. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Features
+
+- App Router with server components
+- Clerk authentication
+- Chatbot interface on the home page
+- API route that proxies requests to OpenAI
+
+This repository is a starting point and does not yet include production configuration or database integration.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "rob-and-hannah",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.0.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "typescript": "^5.4.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { messages } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Missing OpenAI API key' }, { status: 500 });
+  }
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages,
+    }),
+  });
+
+  const data = await response.json();
+  const message = data.choices[0]?.message || { role: 'assistant', content: '' };
+  return NextResponse.json(message);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import './globals.css';
+import { ClerkProvider } from '@clerk/nextjs';
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import React from 'react';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Rob and Hannah AI Assistant',
+  description: 'Personal assistant chatbot for Rob and Hannah',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <ClerkProvider>{children}</ClerkProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,19 @@
+import { currentUser } from '@clerk/nextjs/server';
+import Chat from '../components/Chat';
+
+export default async function HomePage() {
+  const user = await currentUser();
+  if (!user) {
+    return (
+      <main className="flex items-center justify-center h-screen">
+        <p>You must be signed in to use the chatbot.</p>
+      </main>
+    );
+  }
+  return (
+    <main className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Welcome {user.firstName}</h1>
+      <Chat />
+    </main>
+  );
+}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,0 +1,46 @@
+'use client';
+import React, { useState } from 'react';
+
+export default function Chat() {
+  const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMessage = { role: 'user', content: input };
+    setMessages((prev) => [...prev, userMessage]);
+    setInput('');
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [...messages, userMessage] }),
+    });
+    const data = await res.json();
+    setMessages((prev) => [...prev, data]);
+  };
+
+  return (
+    <div>
+      <div className="border p-4 h-64 overflow-y-auto mb-4">
+        {messages.map((m, idx) => (
+          <p key={idx} className="mb-2">
+            <strong>{m.role}:</strong> {m.content}
+          </p>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border p-2"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') sendMessage();
+          }}
+        />
+        <button className="px-4 py-2 bg-blue-500 text-white" onClick={sendMessage}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Next.js 15 project scaffold
- add Tailwind CSS, TypeScript config and lint scripts
- create Clerk-enabled layout with Chat component
- implement basic API route that calls OpenAI
- update README with development info

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876a4060a088331b3b47190565ffdd8